### PR TITLE
Updated scala-parser-combinators dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ version := "0.1.2"
 
 scalaVersion := "2.11.8"
 
-libraryDependencies += "org.scala-lang" % "scala-parser-combinators" % "2.11.0-M4"
+libraryDependencies += "org.scala-lang.modules" % "scala-parser-combinators_2.11" % "1.0.4"
 
 libraryDependencies += "commons-io" % "commons-io" % "2.4"
 


### PR DESCRIPTION
Dependency has been released and now exists under `org.scala-lang.modules`